### PR TITLE
TypeError on task() in GeventThreadPool

### DIFF
--- a/geventreactor/__init__.py
+++ b/geventreactor/__init__.py
@@ -147,7 +147,7 @@ class GeventThreadPool(Group):
 	def callInThreadWithCallback(self,onResult,func,*args,**kwargs):
 		"""Call a callable object in a separate greenlet and call onResult with the return value."""
 		if self.open:
-			def task():
+			def task(*args, **kwargs):
 				try:
 					res = func(*args,**kwargs)
 				except:


### PR DESCRIPTION
task() sometimes throws a TypeError because it's being passed args. Fixed by defining task() to take _args, *_kwargs.
